### PR TITLE
fix(ci): pass app token to trunk upgrade PR creation

### DIFF
--- a/.github/workflows/trunk-upgrade.yml
+++ b/.github/workflows/trunk-upgrade.yml
@@ -24,7 +24,10 @@ jobs:
           token: ${{ inputs.token || github.token }}
 
       - name: Trunk Upgrade
+        id: trunk-upgrade
         uses: trunk-io/trunk-action/upgrade@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
+        with:
+          github-token: ${{ inputs.token || github.token }}
 
       - name: Check if trunk config file changed
         id: version-changed
@@ -32,28 +35,22 @@ jobs:
         with:
           files: .trunk/trunk.yaml
 
-      - name: Create Pull Request
-        if: steps.version-changed.outputs.any_changed == 'true'
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
-        with:
-          token: ${{ inputs.token || github.token }}
-          commit-message: "chore: update trunk configuration"
-          title: "chore: update trunk configuration"
-          body: |
-            This PR updates the trunk configuration based on the monthly trunk upgrade.
-
-            Changes were detected in `.trunk/trunk.yaml`. Please review the changes and merge if appropriate.
-          branch: update-trunk-config
-          delete-branch: true
-
       - name: Output Summary
         env:
           CHANGES_DETECTED: ${{ steps.version-changed.outputs.any_changed }}
+          PULL_REQUEST_OPERATION: ${{ steps.trunk-upgrade.outputs.pull-request-operation }}
+          PULL_REQUEST_URL: ${{ steps.trunk-upgrade.outputs.pull-request-url }}
         run: |
           if [ "$CHANGES_DETECTED" = "true" ]; then
             echo "## 🎉 Trunk Upgrade Summary" >> $GITHUB_STEP_SUMMARY
             echo "A trunk upgrade was performed and changes were detected in \`.trunk/trunk.yaml\`." >> $GITHUB_STEP_SUMMARY
-            echo "A pull request has been created to review these changes." >> $GITHUB_STEP_SUMMARY
+            if [ -n "$PULL_REQUEST_URL" ]; then
+              if [ "$PULL_REQUEST_OPERATION" = "updated" ]; then
+                echo "The existing pull request was updated: $PULL_REQUEST_URL" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "A pull request was created: $PULL_REQUEST_URL" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
           else
             echo "## ℹ️ Trunk Upgrade Summary" >> $GITHUB_STEP_SUMMARY
             echo "No changes were detected in \`.trunk/trunk.yaml\` during the upgrade process." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/trunk-upgrade.yml
+++ b/.github/workflows/trunk-upgrade.yml
@@ -27,6 +27,7 @@ jobs:
         id: trunk-upgrade
         uses: trunk-io/trunk-action/upgrade@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         with:
+          base: ${{ github.ref_name }}
           github-token: ${{ inputs.token || github.token }}
 
       - name: Check if trunk config file changed


### PR DESCRIPTION
## Background

Builds were not triggered in repos even when the correct github token is provided when the action is triggered.

The issue is that the PR is created by the `trunk-io/trunk-action/upgrade` action itself with the default token.

Pass the token to the upgrade action so that the PRs created from the action can trigger builds.
This aligns with Trunk's documented automatic upgrade flow: [Trunk Automatic Upgrades](https://github.com/trunk-io/trunk-action/tree/main?tab=readme-ov-file#automatic-upgrades)

## What Has Changed

Remove the duplicate pull request creation step from the shared trunk upgrade workflow and pass the caller token into Trunk so generated PRs can trigger pull request workflows.

- Removes the redundant standalone Create Pull Request step.
- Passes inputs.token || github.token to trunk-io/trunk-action/upgrade via github-token.
- Leaves PR creation and update ownership with Trunk, while still allowing callers to provide a GitHub App token so normal PR checks can run.

## Screenshots/Video

- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)

