### PR TITLE
fix(generate-changelog): include tag prefix in comparison links

### DIFF
--- a/actions/generate-changelog/generate_changelog.py
+++ b/actions/generate-changelog/generate_changelog.py
@@ -417,20 +417,21 @@ def _update_comparison_links(
     """Rewrite the ``[unreleased]`` link and add a new version link."""
     output: list[str] = []
     updated = False
+    new_tag = f"{cfg.tag_prefix}{cfg.version}"
 
     for line in lines:
         if not updated and _UNRELEASED_LINK_REGEX.match(line):
             output.append(
-                f"[unreleased]: {cfg.repo_url}/compare/{cfg.version}...HEAD\n",
+                f"[unreleased]: {cfg.repo_url}/compare/{new_tag}...HEAD\n",
             )
             if last_tag:
                 output.append(
                     f"[{cfg.version}]: "
-                    f"{cfg.repo_url}/compare/{last_tag}...{cfg.version}\n",
+                    f"{cfg.repo_url}/compare/{last_tag}...{new_tag}\n",
                 )
             else:
                 output.append(
-                    f"[{cfg.version}]: " f"{cfg.repo_url}/releases/tag/{cfg.version}\n",
+                    f"[{cfg.version}]: " f"{cfg.repo_url}/releases/tag/{new_tag}\n",
                 )
             updated = True
         else:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- The `_update_comparison_links` function in `generate_changelog.py` generates GitHub comparison URLs at the bottom of the CHANGELOG (e.g. `[unreleased]: .../compare/1.2.3...HEAD`). When a `tag_prefix` is configured (e.g. `ios-sdk/`), the git tags are prefixed (e.g. `ios-sdk/1.2.3`), but the comparison links were using the bare version number, producing broken URLs.

## What Has Changed

- Constructed the full tag reference (`tag_prefix + version`) before building comparison URLs in `_update_comparison_links`, so that all three link types (unreleased, version-with-previous-tag, and first-release) correctly reference the prefixed tag name.
- No change when `tag_prefix` is empty (defaults to `""`), so this is backward-compatible.

## Screenshots/Video

- N/A

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- The `last_tag` returned by `find_last_tag` already includes the prefix since it comes directly from `git tag` output. The bug was only in the *new* version tag reference, which was built from `cfg.version` alone.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A