### PR TITLE
ci: harden GitHub Actions workflows (artipacked + zizmor CI)

### DIFF
--- a/.github/workflows/trunk-lint.yml
+++ b/.github/workflows/trunk-lint.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python environment
         id: setup-python

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,39 @@
+name: Zizmor Security Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - actions/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - actions/**
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Scan GitHub Actions workflows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        continue-on-error: true # Permanent — reports findings without blocking PRs
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
**TL;DR:** Adds `persist-credentials: false` to `trunk-lint.yml` checkout (prevents credential leakage) and a zizmor security scan workflow (catches future GitHub Actions security issues via inline PR annotations).

---

## What changed

### 1. `trunk-lint.yml` — `persist-credentials: false` on checkout
The checkout step now sets `persist-credentials: false`. This prevents the GitHub token from persisting in the workspace after checkout, mitigating the **artipacked** credential leakage finding flagged by zizmor.

**Safe to add because:** The job only runs lint operations — `actions/setup-python`, `actions/cache`, pip install, and `trunk-io/trunk-action`. No git-write operations.

### 2. New `zizmor.yml` — recurring security scan
Adds a [zizmor](https://github.com/woodruffw/zizmor) security scan that runs on every PR and push touching `.github/workflows/**` or `actions/**`. Uses the official [zizmor-action](https://github.com/zizmorcore/zizmor-action) (v0.5.2, pinned to SHA) for inline PR annotations.

**Note:** Path filter uses `actions/**` (not `.github/actions/**`) because this repo's composite actions live under `actions/` at the repo root (e.g., `actions/generate-changelog/action.yml`).

---

## Design decisions

| Decision | Rationale |
|----------|-----------|
| **`trunk-upgrade.yml` checkout left unchanged** | `trunk-io/trunk-action/upgrade` creates PRs (git-write operation) and `tj-actions/changed-files` needs git credentials for diffing. Adding `persist-credentials: false` would break both. |
| **`oss_pr_opened_notification.yml` unchanged** | No checkout step — just sends a GChat notification via webhook. Nothing to harden. |
| **Existing permissions blocks left as-is** | `contents: write` and `pull-requests: write` on `trunk-upgrade.yml` are required for creating upgrade PRs. `id-token: write` on `oss_pr_opened_notification.yml` is used by callers. Not tightening. |
| **`continue-on-error: true` is permanent** | zizmor runs in advisory mode — reports findings via inline PR annotations without blocking merges. This is the agreed design across the org-wide rollout, per Ashwin (project lead). |
| **`advanced-security: false`** | Kept for consistency with the org-wide template. |
| **`annotations: true`** | Enables inline PR annotations (capped at 10 per run by GitHub). |
| **`ubuntu-24.04` for zizmor** | Pure static analysis — pinned for reproducibility. |
| **Both `pull_request` and `push` triggers** | `pull_request` catches issues before merge. `push` catches direct pushes and ensures a baseline on `main`. |
| **Path filter: `actions/**` not `.github/actions/**`** | This repo's composite actions live under `actions/` at the repo root, not under `.github/actions/`. |

---

## What this PR does NOT change
- **`trunk-upgrade.yml` unchanged** — needs git credentials for PR creation and `changed-files`
- **`oss_pr_opened_notification.yml` unchanged** — no checkout to harden
- **No permissions tightened** — existing `permissions:` blocks are untouched
- **No action version bumps**

---

## Test plan
- [x] Verified `trunk-lint.yml` checkout is NOT followed by git-write operations
- [x] Verified `trunk-upgrade.yml` checkout is skipped (needs git credentials for PR creation + changed-files)
- [x] Verified `oss_pr_opened_notification.yml` has no checkout step
- [x] Verified composite actions live under `actions/` (not `.github/actions/`) — path filter adjusted
- [x] Verified default branch is `main` (used in zizmor.yml triggers)
- [x] Verified checkout SHA matches existing workflows (`de0fac2e4500dabe0009e67214ff5f5447ce83dd` / v6.0.2)
- [x] Verified `zizmor.yml` includes `annotations: true` and `advanced-security: false`
- [x] Verified existing permissions blocks are untouched
- [ ] CI passes (Trunk Lint)